### PR TITLE
Add support for virtual switches V_IND_S and corresponding tests

### DIFF
--- a/custom_components/lifesmart/switch.py
+++ b/custom_components/lifesmart/switch.py
@@ -41,6 +41,7 @@ CON_AI_TYPES = [
     CON_AI_TYPE_GROUP,
 ]
 AI_TYPES = ["ai"]
+VIRTUAL_SWITCH_TYPE = "V_IND_S"
 
 
 def _is_on_type(value) -> bool:
@@ -49,6 +50,15 @@ def _is_on_type(value) -> bool:
         return int(str(value), 0) % 2 == 1
     except (TypeError, ValueError):
         return False
+
+
+def _is_virtual_switch_port(sub_device_key) -> bool:
+    """Return True for V_IND_S virtual switch P-number ports."""
+    return (
+        isinstance(sub_device_key, str)
+        and sub_device_key.startswith("P")
+        and sub_device_key[1:].isdigit()
+    )
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -140,6 +150,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
                 for sub_device_key in device[DEVICE_DATA_KEY]:
                     if sub_device_key in NATURE_SWITCH_PORTS:
+                        switch_devices.append(
+                            LifeSmartSwitch(
+                                ha_device,
+                                device,
+                                sub_device_key,
+                                device[DEVICE_DATA_KEY][sub_device_key],
+                                client,
+                            )
+                        )
+            elif device_type == VIRTUAL_SWITCH_TYPE:
+                for sub_device_key in device[DEVICE_DATA_KEY]:
+                    if _is_virtual_switch_port(sub_device_key):
                         switch_devices.append(
                             LifeSmartSwitch(
                                 ha_device,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1140,6 +1140,7 @@ def test_get_fan_mode(speed, expected):
         ("SL_LK_YL", "HISLK", lifesmart_init.Platform.SENSOR),
         ("SL_OE_DE", "P1", lifesmart_init.Platform.SWITCH),
         ("SL_OE_DE", "P2", lifesmart_init.Platform.SENSOR),
+        ("V_IND_S", "P8", lifesmart_init.Platform.SWITCH),
         ("UNKNOWN", None, ""),
     ],
 )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -109,6 +109,42 @@ def test_async_setup_entry_creates_reported_switch_and_outlet_entities():
     assert any(entity.entity_id == "switch.sl_ol_3c_hub1_outlet1_o" for entity in added)
 
 
+def test_virtual_switch_creates_all_reported_p_ports():
+    devices = [
+        make_device(
+            "V_IND_S",
+            {
+                "P1": {"type": 128, "val": 0, "name": "Up"},
+                "P2": {"type": 128, "val": 0, "name": "Down"},
+                "P3": {"type": "0x80", "val": 0, "name": "Stop"},
+                "P4": {"type": 128, "val": 0, "name": "Power"},
+                "P5": {"type": 128, "val": 0, "name": "Light"},
+                "P6": {"type": 128, "val": 0, "name": "Sterilize"},
+                "P7": {"type": 128, "val": 0, "name": "Fan dry"},
+                "P8": {"type": 128, "val": 0, "name": "Dry"},
+                "B": {"type": 0, "val": 0},
+            },
+            device_id="VIRT1",
+        )
+    ]
+    hass = FakeHass("entry-1", devices, client=FakeClient())
+    added = []
+
+    asyncio.run(switch_module.async_setup_entry(hass, FakeConfigEntry(), lambda entities: added.extend(entities)))
+
+    assert [entity.sub_device_key for entity in added] == [
+        "P1",
+        "P2",
+        "P3",
+        "P4",
+        "P5",
+        "P6",
+        "P7",
+        "P8",
+    ]
+    assert added[-1].entity_id == "switch.v_ind_s_hub1_virt1_p8"
+
+
 def test_switch_entity_properties_updates_and_turn_on_off():
     client = FakeClient(on_results=[0, 1], off_results=[0, 1])
     entity, updates = make_switch_entity(client=client)
@@ -163,6 +199,8 @@ def test_switch_accepts_hex_string_type_from_real_log():
 def test_switch_type_helper_handles_invalid_values():
     assert switch_module._is_on_type(None) is False
     assert switch_module._is_on_type("not-a-number") is False
+    assert switch_module._is_virtual_switch_port("P8") is True
+    assert switch_module._is_virtual_switch_port("B") is False
 
 
 def test_switch_async_added_to_hass_registers_dispatcher(monkeypatch):


### PR DESCRIPTION
These changes should extend the support number of virtual switch under V_IND_S device