### PR TITLE
Support 'Keep Open' state in doorlock alarm

### DIFF
--- a/custom_components/lifesmart/binary_sensor.py
+++ b/custom_components/lifesmart/binary_sensor.py
@@ -560,7 +560,7 @@ def build_doorlock_attribute(data):
 
 def build_doorlock_alarm_attribute(data):
     """Build decoded alarm attributes for digital door lock alarm reports."""
-    val = data.get("val", 0)
+    val = data.get("val", data.get("v", 0))
     return {
         "raw": val,
         "error_alarm": bool(val & (1 << 0)),
@@ -572,6 +572,7 @@ def build_doorlock_alarm_attribute(data):
         "doorbell": bool(val & (1 << 6)),
         "fire_alarm": bool(val & (1 << 7)),
         "intrusion_alarm": bool(val & (1 << 8)),
+        "keep_open": bool(val & (1 << 10)),
         "factory_reset_alarm": bool(val & (1 << 11)),
     }
 

--- a/custom_components/lifesmart/sensor.py
+++ b/custom_components/lifesmart/sensor.py
@@ -81,6 +81,7 @@ DOORLOCK_ALARM_DESCRIPTIONS = {
     "doorbell": "Doorbell",
     "fire_alarm": "Fire alarm",
     "intrusion_alarm": "Intrusion alarm",
+    "keep_open": "Keep Open",
     "factory_reset_alarm": "Factory reset alarm",
 }
 
@@ -714,6 +715,11 @@ class LifeSmartSensor(SensorEntity):
 
 def _display_value(data, device_type=None, sub_device_key=None):
     """Return the display value, falling back to raw tenths for temperature."""
+    if (
+        device_type in LOCK_TYPES
+        and sub_device_key == DIGITAL_DOORLOCK_ALARM_DESCRIPTION_EVENT_KEY
+    ):
+        return _doorlock_alarm_description(data)
     if "v" in data:
         return data["v"]
     if (
@@ -759,11 +765,6 @@ def _display_value(data, device_type=None, sub_device_key=None):
         and sub_device_key == DIGITAL_DOORLOCK_HISTORY_LOCK_EVENT_KEY
     ):
         return _doorlock_history_unlock_summary(data)
-    if (
-        device_type in LOCK_TYPES
-        and sub_device_key == DIGITAL_DOORLOCK_ALARM_DESCRIPTION_EVENT_KEY
-    ):
-        return _doorlock_alarm_description(data)
     if device_type in GENERIC_CONTROLLER_TYPES and sub_device_key == "P1":
         return data.get("val")
     if "val" in data:
@@ -869,7 +870,7 @@ def _state_attributes(data, device_type=None, sub_device_key=None):
 
 def _doorlock_alarm_attributes(data):
     """Build decoded alarm attributes for digital door lock alarm reports."""
-    val = data.get("val", 0)
+    val = _doorlock_alarm_value(data)
     return {
         "error_alarm": bool(val & (1 << 0)),
         "duress_alarm": bool(val & (1 << 1)),
@@ -880,6 +881,7 @@ def _doorlock_alarm_attributes(data):
         "doorbell": bool(val & (1 << 6)),
         "fire_alarm": bool(val & (1 << 7)),
         "intrusion_alarm": bool(val & (1 << 8)),
+        "keep_open": bool(val & (1 << 10)),
         "factory_reset_alarm": bool(val & (1 << 11)),
     }
 
@@ -892,6 +894,11 @@ def _doorlock_alarm_description(data):
         if _doorlock_alarm_attributes(data)[key]
     ]
     return ", ".join(active) if active else "Normal"
+
+
+def _doorlock_alarm_value(data):
+    """Return the raw digital door lock alarm bitfield."""
+    return data.get("val", data.get("v", 0))
 
 
 DOORLOCK_UNLOCKING_METHODS = {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -165,6 +165,7 @@ def test_lock_binary_sensor_variants_and_attributes():
         "doorbell": False,
         "fire_alarm": False,
         "intrusion_alarm": False,
+        "keep_open": False,
         "factory_reset_alarm": False,
     }
 
@@ -266,3 +267,6 @@ def test_doorlock_helper_functions_cover_known_and_unknown_methods():
         "unlocking_method": "Bluetooth unlocking",
         "unlocking_user": 11,
     }
+    assert binary_sensor_module.build_doorlock_alarm_attribute({"v": 1024})[
+        "keep_open"
+    ] is True

--- a/tests/test_sensor_module.py
+++ b/tests/test_sensor_module.py
@@ -206,6 +206,7 @@ def test_sensor_entity_branches_and_properties():
         "doorbell": False,
         "fire_alarm": False,
         "intrusion_alarm": False,
+        "keep_open": False,
         "factory_reset_alarm": False,
         "raw": 17,
     }
@@ -280,6 +281,10 @@ def test_sensor_helper_functions_cover_remaining_paths():
         sensor_module._display_value({"val": 0b10001}, "SL_LK_YL", "ALM_DESC")
         == "Error alarm, Low battery alarm"
     )
+    assert (
+        sensor_module._display_value({"val": 1024, "v": 1024}, "SL_LK_YL", "ALM_DESC")
+        == "Keep Open"
+    )
     assert sensor_module._display_value({"val": 0}, "SL_LK_YL", "ALM_DESC") == "Normal"
     assert (
         sensor_module._display_value({"val": 0x1001}, "SL_LK_YL", "HISLK")
@@ -315,6 +320,7 @@ def test_sensor_helper_functions_cover_remaining_paths():
         "doorbell": False,
         "fire_alarm": False,
         "intrusion_alarm": False,
+        "keep_open": False,
         "factory_reset_alarm": False,
         "raw": 17,
     }


### PR DESCRIPTION
Currently when Digital Door lock is in `Keep Open` mode, The alarm will show as 1024. 

These changes should ensure it shown correctly as Keep Open in Alarm description