### PR TITLE
Add support for Scene from LifeSmart 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use manual installation only if you cannot use HACS.
    - **LifeSmart Account Country/Region**: Select the country or region shown in the LifeSmart mobile app account/profile screen (see below)
 1. Click `Submit` and wait for device discovery.
 
-The integration will automatically discover and create entities for all your LifeSmart devices.
+The integration will automatically discover and create entities for all your LifeSmart devices and scenes.
 
 ### Finding Your LifeSmart Email/User ID And Country/Region
 
@@ -89,6 +89,18 @@ Support is based on the attributes returned by the LifeSmart API. Some models cr
 | Nature series | `SL_NATURE` | Switch-board variants create `P1-P3` switches; thermostat variants create a climate entity; `P4` temperature is exposed when reported | Variant is detected from the reported attributes. |
 | Native A/C panels | `V_AIR_P`, `V_SZJSXR_P`, `V_T8600_P`, `SL_CP_DN` | Climate entities | These use LifeSmart native `EpSet` control, not SPOT IR profiles. |
 | SPOT and IR remotes | `SL_SPOT`, `MSL_IRCTL`, `OD_WE_IRCTL`, `SL_P_IR`, `SL_P_IR_V2` | Infrared emitter entities for Home Assistant IR device integrations; existing remote entities for IR command storage/sending; optional A/C climate entities; light entities only on SPOT models with light attributes | Requires Home Assistant 2026.6 or newer. `SL_P_IR` and `SL_P_IR_V2` do not create light entities. `SL_P_IR_V2` exposes pairing-button `P2` as a binary sensor when reported. |
+
+## LifeSmart Scenes
+
+Scenes configured in the LifeSmart app are discovered automatically for each included hub and exposed as native Home Assistant `scene` entities. Activate one from a dashboard, script, or automation with `scene.turn_on`:
+
+```yaml
+action: scene.turn_on
+target:
+  entity_id: scene.movie_night
+```
+
+LifeSmart remains responsible for executing the scene actions. Scene changes made in the LifeSmart app appear after reloading the LifeSmart integration. The legacy `lifesmart.scene_set` action remains available for automations that use raw hub and scene IDs.
 
 ## FAQ
 

--- a/custom_components/lifesmart/__init__.py
+++ b/custom_components/lifesmart/__init__.py
@@ -138,11 +138,16 @@ def _runtime_for_service(hass: HomeAssistant, data: dict) -> LifeSmartRuntimeDat
         runtime = getattr(entry, "runtime_data", None)
         if not isinstance(runtime, LifeSmartRuntimeData):
             continue
-        if any(
+        device_matches = any(
             device.get(HUB_ID_KEY) == hub_id
             and (device_id is None or device.get(DEVICE_ID_KEY) == device_id)
             for device in runtime.devices
-        ):
+        )
+        hub_matches = device_id is None and (
+            any(hub.get(HUB_ID_KEY) == hub_id for hub in runtime.hubs)
+            or any(scene.get(HUB_ID_KEY) == hub_id for scene in runtime.scenes)
+        )
+        if device_matches or hub_matches:
             matches.append(runtime)
     if len(matches) != 1:
         raise ServiceValidationError(
@@ -286,6 +291,75 @@ async def _async_refresh_device_availability(
         runtime_data.set_device_available(hub_id, device_id, status == 1)
 
 
+async def _async_discover_scenes(
+    client: LifeSmartClient,
+    hub_ids: set[str],
+    exclude_hubs: list[str],
+) -> list[dict]:
+    """Discover and normalize scenes without blocking normal device setup."""
+
+    async def async_get_hub_scenes(hub_id: str) -> tuple[str, object]:
+        try:
+            return hub_id, await client.get_all_scene_async(hub_id)
+        except Exception as err:  # Scene support is optional for existing entries.
+            _LOGGER.warning(
+                "Unable to retrieve LifeSmart scenes for hub %s: %s",
+                hub_id,
+                type(err).__name__,
+            )
+            return hub_id, None
+
+    included_hubs = sorted(hub_ids - set(exclude_hubs))
+    responses = await asyncio.gather(
+        *(async_get_hub_scenes(hub_id) for hub_id in included_hubs)
+    )
+    scenes = []
+    seen_scene_keys = set()
+    for hub_id, response in responses:
+        if response is None:
+            continue
+        if not isinstance(response, list):
+            _LOGGER.warning(
+                "LifeSmart scene discovery returned an invalid response for hub %s",
+                hub_id,
+            )
+            continue
+        for raw_scene in response:
+            if not isinstance(raw_scene, dict):
+                _LOGGER.debug(
+                    "Ignoring invalid LifeSmart scene entry for hub %s", hub_id
+                )
+                continue
+            raw_scene_id = raw_scene.get("id")
+            if raw_scene_id is None:
+                _LOGGER.debug(
+                    "Ignoring LifeSmart scene without an ID for hub %s", hub_id
+                )
+                continue
+            scene_id = str(raw_scene_id).strip()
+            if not scene_id:
+                continue
+            scene_key = (hub_id, scene_id)
+            if scene_key in seen_scene_keys:
+                _LOGGER.debug(
+                    "Ignoring duplicate LifeSmart scene %s for hub %s",
+                    scene_id,
+                    hub_id,
+                )
+                continue
+            seen_scene_keys.add(scene_key)
+            raw_name = raw_scene.get("name")
+            name = str(raw_name).strip() if raw_name is not None else ""
+            scenes.append(
+                {
+                    HUB_ID_KEY: hub_id,
+                    "id": scene_id,
+                    "name": name or f"LifeSmart Scene {scene_id}",
+                }
+            )
+    return scenes
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):  # noqa: C901
     """Initialize a setup of the lifesamrt addon."""
     hass.data.setdefault(DOMAIN, {})
@@ -398,6 +472,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):  # 
 
     await asyncio.gather(*(async_enrich_hub(hub) for hub in hubs_by_id.values()))
 
+    scenes = await _async_discover_scenes(lifesmart_client, hub_ids, exclude_hubs)
+
     hub_device_registry_ids = {}
     for hub_id in hub_ids:
         hub = hubs_by_id[hub_id]
@@ -434,6 +510,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):  # 
         client=lifesmart_client,
         devices=devices,
         hubs=list(hubs_by_id.values()),
+        scenes=scenes,
         exclude_devices=exclude_devices,
         exclude_hubs=exclude_hubs,
         ai_include_hubs=ai_include_hubs,
@@ -958,13 +1035,6 @@ class LifeSmartDevice(LifeSmartAvailabilityMixin, Entity):
         agt = self._agt
         me = self._me
         return await self._client.get_epget_async(agt, me)
-
-    async def async_lifesmart_sceneset(self, type, rgbw):
-        """Set the scene."""
-        agt = self._agt
-        id = self._me
-        response = self._client.set_scene_async(agt, id)
-        return response["code"]
 
 
 class LifeSmartStatesManager(threading.Thread):

--- a/custom_components/lifesmart/const.py
+++ b/custom_components/lifesmart/const.py
@@ -18,15 +18,6 @@ IR_CATEGORY_AC = "ac"
 # Internal key used to link child devices to their Home Assistant hub device.
 HUB_DEVICE_REGISTRY_ID_KEY = "_ha_hub_device_registry_id"
 
-CON_AI_TYPE_SCENE = "scene"
-CON_AI_TYPE_AIB = "aib"
-CON_AI_TYPE_GROUP = "grouphw"
-CON_AI_TYPES = [
-    CON_AI_TYPE_SCENE,
-    CON_AI_TYPE_AIB,
-    CON_AI_TYPE_GROUP,
-]
-AI_TYPES = ["ai"]
 SUPPORTED_SWTICH_TYPES = [
     "OD_WE_OT1",
     "SL_MC_ND1",
@@ -219,6 +210,7 @@ SUPPORTED_PLATFORMS = [
     Platform.INFRARED,
     Platform.CLIMATE,
     Platform.BUTTON,
+    Platform.SCENE,
 ]
 AIR_CONDITIONER_TYPES = [
     "V_AIR_P",

--- a/custom_components/lifesmart/diagnostics.py
+++ b/custom_components/lifesmart/diagnostics.py
@@ -46,4 +46,5 @@ async def async_get_config_entry_diagnostics(
             "excluded_device_count": len(runtime.exclude_devices),
             "excluded_hub_count": len(runtime.exclude_hubs),
         },
+        "scenes": {"count": len(runtime.scenes)},
     }

--- a/custom_components/lifesmart/runtime_data.py
+++ b/custom_components/lifesmart/runtime_data.py
@@ -17,6 +17,7 @@ class LifeSmartRuntimeData:
     client: LifeSmartClient
     devices: list[dict[str, Any]]
     hubs: list[dict[str, Any]] = field(default_factory=list)
+    scenes: list[dict[str, Any]] = field(default_factory=list)
     hub_coordinator: Any | None = None
     exclude_devices: list[str] = field(default_factory=list)
     exclude_hubs: list[str] = field(default_factory=list)
@@ -119,6 +120,7 @@ def get_runtime_data(hass, entry) -> LifeSmartRuntimeData:
         client=legacy.get("client"),
         devices=legacy["devices"],
         hubs=legacy.get("hubs", []),
+        scenes=legacy.get("scenes", []),
         hub_coordinator=legacy.get("hub_coordinator"),
         exclude_devices=legacy.get("exclude_devices", []),
         exclude_hubs=legacy.get("exclude_hubs", []),

--- a/custom_components/lifesmart/scene.py
+++ b/custom_components/lifesmart/scene.py
@@ -1,0 +1,60 @@
+"""Support for LifeSmart scenes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.scene import Scene
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN, HUB_ID_KEY
+from .runtime_data import get_runtime_data
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+    """Set up scenes discovered from the LifeSmart cloud API."""
+    runtime = get_runtime_data(hass, config_entry)
+    async_add_entities(
+        LifeSmartScene(runtime.client, scene) for scene in runtime.scenes
+    )
+
+
+class LifeSmartScene(Scene):
+    """A stateless scene executed by a LifeSmart hub."""
+
+    def __init__(self, client, scene: dict[str, Any]) -> None:
+        """Initialize a LifeSmart scene."""
+        self._client = client
+        self._hub_id = scene[HUB_ID_KEY]
+        self._scene_id = scene["id"]
+        self._attr_name = scene["name"]
+        self._attr_unique_id = f"{self._hub_id}_{self._scene_id}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach the scene to the hub which executes it."""
+        return DeviceInfo(identifiers={(DOMAIN, self._hub_id)})
+
+    async def async_activate(self, **kwargs: Any) -> None:
+        """Activate the scene through the LifeSmart cloud API."""
+        try:
+            response = await self._client.set_scene_async(self._hub_id, self._scene_id)
+        except Exception as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="scene_activation_failed",
+            ) from err
+
+        if isinstance(response, int):
+            accepted = response == 0
+        else:
+            accepted = isinstance(response, dict) and response.get("code") in (
+                0,
+                "success",
+            )
+        if not accepted:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="scene_activation_rejected",
+            )

--- a/custom_components/lifesmart/scene.py
+++ b/custom_components/lifesmart/scene.py
@@ -46,13 +46,12 @@ class LifeSmartScene(Scene):
                 translation_key="scene_activation_failed",
             ) from err
 
-        if isinstance(response, int):
+        if type(response) is int:
             accepted = response == 0
         else:
-            accepted = isinstance(response, dict) and response.get("code") in (
-                0,
-                "success",
-            )
+            response_code = response.get("code") if isinstance(response, dict) else None
+            accepted = type(response_code) is int and response_code == 0
+            accepted = accepted or response_code == "success"
         if not accepted:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/lifesmart/switch.py
+++ b/custom_components/lifesmart/switch.py
@@ -33,15 +33,6 @@ from .runtime_data import LifeSmartAvailabilityMixin, get_runtime_data
 
 _LOGGER = logging.getLogger(__name__)
 
-CON_AI_TYPE_SCENE = "scene"
-CON_AI_TYPE_AIB = "aib"
-CON_AI_TYPE_GROUP = "grouphw"
-CON_AI_TYPES = [
-    CON_AI_TYPE_SCENE,
-    CON_AI_TYPE_AIB,
-    CON_AI_TYPE_GROUP,
-]
-AI_TYPES = ["ai"]
 VIRTUAL_SWITCH_TYPE = "V_IND_S"
 
 
@@ -91,9 +82,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 client,
             )
 
-            if device_type in AI_TYPES:
-                switch_devices.append(LifeSmartSceneSwitch(ha_device, device, client))
-            elif device_type in AIR_PURIFIER_TYPES:
+            if device_type in AIR_PURIFIER_TYPES:
                 sub_device_key = "O"
                 switch_devices.append(
                     LifeSmartSwitch(
@@ -292,72 +281,6 @@ class LifeSmartSwitch(LifeSmartAvailabilityMixin, SwitchEntity):
             self.async_schedule_update_ha_state()
         else:
             _LOGGER.warning("Switch {self._me} - {self._idx} status changed failed")
-
-    @property
-    def unique_id(self):
-        """A unique identifier for this entity."""
-        return self._attr_unique_id
-
-
-class LifeSmartSceneSwitch(LifeSmartDevice, SwitchEntity):
-    def __init__(self, device, raw_device_data, client) -> None:
-        """Initialize the switch."""
-
-        device_type = raw_device_data[DEVICE_TYPE_KEY]
-        hub_id = raw_device_data[HUB_ID_KEY]
-        device_id = raw_device_data[DEVICE_ID_KEY]
-
-        super().__init__(raw_device_data, client)
-
-        self._device = device
-        self._raw_device_data = raw_device_data
-        configure_entity_identity(
-            self,
-            generate_entity_id(device_type, hub_id, device_id)
-            or f"switch.{device_type}_{hub_id}_{device_id}".lower(),
-        )
-
-        self.hub_id = hub_id
-        self.device_id = device_id
-        self.device_type = device_type
-        self.switch_name = raw_device_data[DEVICE_NAME_KEY]
-
-        self._state = False
-
-    @property
-    def is_on(self):
-        """Return true if device is on."""
-        return self._state
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info."""
-        return DeviceInfo(
-            identifiers={device_identifier(self.hub_id, self.device_id)},
-            name=self.switch_name,
-            manufacturer=MANUFACTURER,
-            model=self.device_type,
-            # sw_version=self.light.swversion,
-            **device_via_info(self._raw_device_data, self.hub_id),
-        )
-
-    async def async_added_to_hass(self):
-        """Call when entity is added to hass."""
-
-    def _get_state(self):
-        """Get lifesmart switch state."""
-        return self._state
-
-    async def async_turn_on(self, **kwargs):
-        """Set scene."""
-        if await super().async_lifesmart_sceneset(None, None) == 0:
-            self._state = True
-            self.async_schedule_update_ha_state()
-
-    async def async_turn_off(self, **kwargs):
-        """TODO: Set scene off ?."""
-        self._state = False
-        self.async_schedule_update_ha_state()
 
     @property
     def unique_id(self):

--- a/custom_components/lifesmart/translations/en.json
+++ b/custom_components/lifesmart/translations/en.json
@@ -115,6 +115,12 @@
     "hub_restart_rejected": {
       "message": "LifeSmart rejected the hub restart request."
     },
+    "scene_activation_failed": {
+      "message": "Unable to activate the LifeSmart scene."
+    },
+    "scene_activation_rejected": {
+      "message": "LifeSmart rejected the scene activation request."
+    },
     "service_target_not_found": {
       "message": "The target does not belong to exactly one loaded LifeSmart account."
     },

--- a/custom_components/lifesmart/translations/es.json
+++ b/custom_components/lifesmart/translations/es.json
@@ -115,6 +115,12 @@
     "hub_restart_rejected": {
       "message": "LifeSmart rechazó la solicitud de reinicio del concentrador."
     },
+    "scene_activation_failed": {
+      "message": "No se pudo activar la escena de LifeSmart."
+    },
+    "scene_activation_rejected": {
+      "message": "LifeSmart rechazó la solicitud de activación de la escena."
+    },
     "service_target_not_found": {
       "message": "El destino no pertenece exactamente a una cuenta de LifeSmart cargada."
     },

--- a/custom_components/lifesmart/translations/th.json
+++ b/custom_components/lifesmart/translations/th.json
@@ -115,6 +115,12 @@
     "hub_restart_rejected": {
       "message": "LifeSmart ปฏิเสธคำขอรีสตาร์ทฮับ"
     },
+    "scene_activation_failed": {
+      "message": "ไม่สามารถเปิดใช้งานซีน LifeSmart ได้"
+    },
+    "scene_activation_rejected": {
+      "message": "LifeSmart ปฏิเสธคำขอเปิดใช้งานซีน"
+    },
     "service_target_not_found": {
       "message": "เป้าหมายไม่ได้อยู่ในบัญชี LifeSmart ที่โหลดไว้เพียงบัญชีเดียว"
     },

--- a/custom_components/lifesmart/translations/zh-Hans.json
+++ b/custom_components/lifesmart/translations/zh-Hans.json
@@ -115,6 +115,12 @@
     "hub_restart_rejected": {
       "message": "LifeSmart 拒绝了网关重启请求。"
     },
+    "scene_activation_failed": {
+      "message": "无法激活 LifeSmart 场景。"
+    },
+    "scene_activation_rejected": {
+      "message": "LifeSmart 拒绝了场景激活请求。"
+    },
     "service_target_not_found": {
       "message": "目标未明确属于一个已加载的 LifeSmart 账号。"
     },

--- a/info.md
+++ b/info.md
@@ -26,6 +26,7 @@ Current supported features:
 - SPOT A/C climate control through LifeSmart A/C remote profiles
 - Native A/C control panel climate entities
 - Nature Series switch, temperature, and thermostat support
+- Native Home Assistant scene entities for scenes configured in LifeSmart
 
 SPOT support currently includes:
 - `SL_SPOT`
@@ -131,6 +132,7 @@ Important notes:
 
 Main setup/configuration capabilities:
 - Standard integration setup through the Home Assistant UI
+- Automatic LifeSmart scene discovery for each included hub
 - SPOT A/C assignment through the integration options flow
 - Use of the existing A/C remote assignment returned by LifeSmart `GetRemoteList`
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -26,6 +26,7 @@ def test_diagnostics_redacts_credentials_and_summarizes_devices():
         runtime_data=LifeSmartRuntimeData(
             client=None,
             devices=[{"devtype": "SL_SPOT"}, {"devtype": "SL_SPOT"}],
+            scenes=[{"agt": "HUB1", "id": "SCENE1", "name": "Movie Night"}],
             connected=False,
             last_error="offline",
         ),
@@ -40,3 +41,4 @@ def test_diagnostics_redacts_credentials_and_summarizes_devices():
     assert result["connection"] == {"connected": False, "last_error": "offline"}
     assert result["devices"]["count"] == 2
     assert result["devices"]["types"] == {"SL_SPOT": 2}
+    assert result["scenes"] == {"count": 1}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -72,6 +72,38 @@ def test_refresh_device_availability_uses_cloud_status():
     }
 
 
+def test_scene_discovery_normalizes_filters_and_deduplicates(caplog):
+    class SceneClient:
+        def __init__(self):
+            self.calls = []
+
+        async def get_all_scene_async(self, hub_id):
+            self.calls.append(hub_id)
+            if hub_id == "HUB2":
+                raise RuntimeError("private API failure")
+            return [
+                {"id": "SCENE1", "name": " Movie Night ", "ignored": "raw"},
+                {"id": "SCENE1", "name": "Duplicate"},
+                {"id": 7},
+                {"name": "Missing ID"},
+                "invalid",
+            ]
+
+    client = SceneClient()
+    scenes = asyncio.run(
+        lifesmart_init._async_discover_scenes(
+            client, {"HUB3", "HUB2", "HUB1"}, ["HUB3"]
+        )
+    )
+
+    assert client.calls == ["HUB1", "HUB2"]
+    assert scenes == [
+        {HUB_ID_KEY: "HUB1", "id": "SCENE1", "name": "Movie Night"},
+        {HUB_ID_KEY: "HUB1", "id": "7", "name": "LifeSmart Scene 7"},
+    ]
+    assert "Unable to retrieve LifeSmart scenes for hub HUB2" in caplog.text
+
+
 class FakeConfigEntriesManager:
     def __init__(self):
         self.forward_calls = []
@@ -207,6 +239,7 @@ class FakeLifeSmartClient:
         self.userpassword = userpassword
         self.login_calls = 0
         self.device_calls = 0
+        self.scene_calls = []
         self.service_calls = []
         FakeLifeSmartClient.instances.append(self)
 
@@ -220,6 +253,10 @@ class FakeLifeSmartClient:
 
     async def get_all_hubs_async(self):
         return self.hubs_response
+
+    async def get_all_scene_async(self, hub_id):
+        self.scene_calls.append(hub_id)
+        return []
 
     async def get_hub_system_info_async(self, hub_id):
         return self.system_info_response
@@ -440,8 +477,10 @@ def test_async_setup_entry_initializes_client_services_and_websocket(monkeypatch
     assert runtime.exclude_hubs == []
     assert runtime.ai_include_hubs == []
     assert runtime.ai_include_items == []
+    assert runtime.scenes == []
     assert runtime.update_listener == "listener-token"
     assert {hub[HUB_ID_KEY] for hub in runtime.hubs} == {"HUB1", "HUB2"}
+    assert client.scene_calls == ["HUB1", "HUB2"]
     assert config_entry.update_listener is lifesmart_init._async_update_listener
     assert len(device_reg.created) == 2
     assert {entry["name"] for entry in device_reg.created} == {
@@ -588,6 +627,23 @@ def test_central_service_handler_rejects_ambiguous_target():
         lifesmart_init._runtime_for_service(
             hass, {HUB_ID_KEY: "HUB1", DEVICE_ID_KEY: "DEVICE1"}
         )
+
+
+def test_central_scene_service_resolves_hub_without_devices():
+    entry = make_config_entry()
+    entry.runtime_data = lifesmart_init.LifeSmartRuntimeData(
+        client=object(),
+        devices=[],
+        hubs=[{HUB_ID_KEY: "HUB1"}],
+        scenes=[{HUB_ID_KEY: "HUB1", "id": "SCENE1"}],
+    )
+    hass = FakeHass()
+    hass.config_entries.entries = [entry]
+
+    assert (
+        lifesmart_init._runtime_for_service(hass, {HUB_ID_KEY: "HUB1"})
+        is entry.runtime_data
+    )
 
 
 @pytest.mark.parametrize(
@@ -1605,7 +1661,6 @@ class FakeBaseClient:
     def __init__(self):
         self.epset_calls = []
         self.epget_calls = []
-        self.scene_calls = []
 
     async def send_epset_async(self, type, val, idx, agt, me):
         self.epset_calls.append((type, val, idx, agt, me))
@@ -1614,10 +1669,6 @@ class FakeBaseClient:
     async def get_epget_async(self, agt, me):
         self.epget_calls.append((agt, me))
         return {"value": 1}
-
-    def set_scene_async(self, agt, scene_id):
-        self.scene_calls.append((agt, scene_id))
-        return {"code": 0}
 
 
 def test_lifesmart_device_exposes_metadata_and_proxies_client_calls():
@@ -1642,10 +1693,8 @@ def test_lifesmart_device_exposes_metadata_and_proxies_client_calls():
     assert device.should_poll is False
     assert asyncio.run(device.async_lifesmart_epset("0x81", 1, "P1")) == "epset-ok"
     assert asyncio.run(device.async_lifesmart_epget()) == {"value": 1}
-    assert asyncio.run(device.async_lifesmart_sceneset("ignored", "ignored")) == 0
     assert client.epset_calls == [("0x81", 1, "P1", "HUB1", "DEV1")]
     assert client.epget_calls == [("HUB1", "DEV1")]
-    assert client.scene_calls == [("HUB1", "DEV1")]
 
 
 def test_states_manager_run_start_and_stop(monkeypatch):

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,0 +1,94 @@
+"""Tests for native LifeSmart scene entities."""
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.lifesmart.const import DOMAIN, HUB_ID_KEY
+from custom_components.lifesmart.runtime_data import LifeSmartRuntimeData
+
+scene_module = importlib.import_module("custom_components.lifesmart.scene")
+
+_UNSET = object()
+
+
+class FakeClient:
+    def __init__(self, response=_UNSET, error=None):
+        self.response = {"code": 0} if response is _UNSET else response
+        self.error = error
+        self.calls = []
+
+    async def set_scene_async(self, hub_id, scene_id):
+        self.calls.append((hub_id, scene_id))
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def make_scene(client=None):
+    return scene_module.LifeSmartScene(
+        client or FakeClient(),
+        {HUB_ID_KEY: "HUB1", "id": "SCENE1", "name": "Movie Night"},
+    )
+
+
+def test_scene_setup_creates_native_entities():
+    client = FakeClient()
+    entry = SimpleNamespace(
+        runtime_data=LifeSmartRuntimeData(
+            client=client,
+            devices=[],
+            scenes=[
+                {HUB_ID_KEY: "HUB1", "id": "SCENE1", "name": "Movie Night"},
+                {HUB_ID_KEY: "HUB2", "id": "SCENE1", "name": "Away"},
+            ],
+        )
+    )
+    added = []
+
+    asyncio.run(
+        scene_module.async_setup_entry(
+            object(), entry, lambda entities: added.extend(entities)
+        )
+    )
+
+    assert [entity.name for entity in added] == ["Movie Night", "Away"]
+    assert [entity.unique_id for entity in added] == [
+        "HUB1_SCENE1",
+        "HUB2_SCENE1",
+    ]
+    assert added[0].device_info["identifiers"] == {(DOMAIN, "HUB1")}
+
+
+@pytest.mark.parametrize("response", [{"code": 0}, {"code": "success"}, 0])
+def test_scene_activation_calls_lifesmart(response):
+    client = FakeClient(response=response)
+    scene = make_scene(client)
+
+    asyncio.run(scene.async_activate())
+
+    assert client.calls == [("HUB1", "SCENE1")]
+
+
+@pytest.mark.parametrize("response", [{"code": 1}, 1, None, "invalid"])
+def test_scene_activation_reports_rejected_request(response):
+    client = FakeClient(response=response)
+    scene = make_scene(client)
+
+    with pytest.raises(scene_module.HomeAssistantError) as error:
+        asyncio.run(scene.async_activate())
+
+    assert error.value.translation_key == "scene_activation_rejected"
+
+
+def test_scene_activation_wraps_client_error():
+    client = FakeClient(error=RuntimeError("private API failure"))
+    scene = make_scene(client)
+
+    with pytest.raises(scene_module.HomeAssistantError) as error:
+        asyncio.run(scene.async_activate())
+
+    assert error.value.translation_key == "scene_activation_failed"
+    assert isinstance(error.value.__cause__, RuntimeError)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -72,7 +72,10 @@ def test_scene_activation_calls_lifesmart(response):
     assert client.calls == [("HUB1", "SCENE1")]
 
 
-@pytest.mark.parametrize("response", [{"code": 1}, 1, None, "invalid"])
+@pytest.mark.parametrize(
+    "response",
+    [{"code": 1}, {"code": False}, 1, False, None, "invalid"],
+)
 def test_scene_activation_reports_rejected_request(response):
     client = FakeClient(response=response)
     scene = make_scene(client)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -39,11 +39,6 @@ class FakeClient:
         return self.off_results.pop(0) if self.off_results else 0
 
 
-class FakeSceneClient(FakeClient):
-    async def set_scene_async(self, agt, scene_id):
-        return {"code": 0}
-
-
 def make_device(device_type, data, device_id="DEV1", hub_id="HUB1"):
     return {
         "name": "Switch Device",
@@ -220,23 +215,3 @@ def test_switch_async_added_to_hass_registers_dispatcher(monkeypatch):
 
     assert calls[0][1] == f"{switch_module.LIFESMART_SIGNAL_UPDATE_ENTITY}_{entity.unique_id}"
     assert removers == ["remove-token"]
-
-
-def test_scene_switch_turns_on_and_off(monkeypatch):
-    raw = make_device("ai", {})
-    scene = switch_module.LifeSmartSceneSwitch(None, raw, FakeSceneClient())
-    updates = []
-    scene.async_schedule_update_ha_state = lambda: updates.append("scheduled")
-
-    async def fake_scene_set(*args):
-        return 0
-
-    monkeypatch.setattr(switch_module.LifeSmartDevice, "async_lifesmart_sceneset", fake_scene_set)
-
-    asyncio.run(scene.async_turn_on())
-    asyncio.run(scene.async_turn_off())
-
-    assert scene.device_info["model"] == "ai"
-    assert scene.entity_id is None
-    assert scene._get_state() is False
-    assert updates == ["scheduled", "scheduled"]


### PR DESCRIPTION
This should fix #79 

- LifeSmart scenes will be created as scenes in Home Assistant.
- The scenes will still be managed by LifeSmart; Home Assistant will only provide the ability to activate them.
- Any changes made to scenes in LifeSmart will require the integration to be reloaded or Home Assistant to be restarted before the changes are reflected.
- Legacy LifeSmart Scene Switch will no longer work. 