### PR TITLE
Bind LifeSmart discovery to enabled Home Assistant interfaces

### DIFF
--- a/custom_components/lifesmart/lifesmart_client_local.py
+++ b/custom_components/lifesmart/lifesmart_client_local.py
@@ -18,7 +18,11 @@ import zlib
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
+from ipaddress import IPv4Address
 from typing import Any, cast
+
+from homeassistant.components import network
+from homeassistant.core import async_get_hass_or_none
 
 from .const import (
     DEVICE_DATA_KEY,
@@ -206,11 +210,58 @@ class _LifeSmartDiscoveryProtocol(asyncio.DatagramProtocol):
         _LOGGER.debug("LifeSmart local discovery socket error: %s", exc)
 
 
-async def _async_open_discovery_transport(
+class _LifeSmartDiscoveryTransport(asyncio.DatagramTransport):
+    """Fan discovery probes out through one socket per enabled IPv4 address."""
+
+    def __init__(
+        self, transports: Sequence[tuple[str, asyncio.DatagramTransport]]
+    ) -> None:
+        self._transports = tuple(transports)
+
+    def sendto(self, data: bytes, addr: tuple[str, int] | None = None) -> None:
+        """Send one probe through every enabled Home Assistant interface."""
+        for source_ip, transport in self._transports:
+            try:
+                transport.sendto(data, addr)
+            except OSError as err:
+                _LOGGER.debug(
+                    "Unable to send LifeSmart discovery probe from %s to %s: %s",
+                    source_ip,
+                    addr,
+                    err,
+                )
+
+    def close(self) -> None:
+        """Close every interface-specific discovery socket."""
+        for _source_ip, transport in self._transports:
+            transport.close()
+
+
+async def _async_get_discovery_source_ips() -> list[str]:
+    """Return enabled Home Assistant IPv4 addresses for local discovery."""
+    hass = async_get_hass_or_none()
+    if hass is None:
+        _LOGGER.debug(
+            "Skipping LifeSmart local discovery outside a Home Assistant context"
+        )
+        return []
+
+    source_ips = await network.async_get_enabled_source_ips(hass)
+    return list(
+        dict.fromkeys(
+            str(source_ip)
+            for source_ip in source_ips
+            if isinstance(source_ip, IPv4Address) and not source_ip.is_unspecified
+        )
+    )
+
+
+async def _async_open_discovery_socket(
+    source_ip: str,
     preferred_port: int,
     hubs: dict[tuple[str, str], DiscoveredLifeSmartHub],
 ) -> asyncio.DatagramTransport | None:
-    """Open one broadcast-capable listener, falling back to an ephemeral port."""
+    """Open one discovery listener bound to a specific IPv4 address."""
     loop = asyncio.get_running_loop()
     for local_port in (preferred_port, 0):
         discovery_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -218,7 +269,12 @@ async def _async_open_discovery_transport(
             discovery_socket.setblocking(False)
             discovery_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
             discovery_socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
-            discovery_socket.bind(("", local_port))
+            discovery_socket.setsockopt(
+                socket.IPPROTO_IP,
+                socket.IP_MULTICAST_IF,
+                socket.inet_aton(source_ip),
+            )
+            discovery_socket.bind((source_ip, local_port))
             transport, _ = await loop.create_datagram_endpoint(
                 lambda: _LifeSmartDiscoveryProtocol(hubs), sock=discovery_socket
             )
@@ -226,16 +282,39 @@ async def _async_open_discovery_transport(
             discovery_socket.close()
             if local_port == preferred_port:
                 _LOGGER.debug(
-                    "Unable to bind LifeSmart discovery port %s; using an "
+                    "Unable to bind LifeSmart discovery port %s on %s; using an "
                     "ephemeral port: %s",
                     preferred_port,
+                    source_ip,
                     err,
                 )
                 continue
-            _LOGGER.debug("Unable to open LifeSmart discovery socket: %s", err)
+            _LOGGER.debug(
+                "Unable to open LifeSmart discovery socket on %s: %s", source_ip, err
+            )
             return None
         return cast(asyncio.DatagramTransport, transport)
     return None
+
+
+async def _async_open_discovery_transport(
+    preferred_port: int,
+    hubs: dict[tuple[str, str], DiscoveredLifeSmartHub],
+) -> asyncio.DatagramTransport | None:
+    """Open discovery listeners on every enabled Home Assistant IPv4 address."""
+    source_ips = await _async_get_discovery_source_ips()
+    if not source_ips:
+        return None
+
+    transports: list[tuple[str, asyncio.DatagramTransport]] = []
+    for source_ip in source_ips:
+        transport = await _async_open_discovery_socket(source_ip, preferred_port, hubs)
+        if transport is not None:
+            transports.append((source_ip, transport))
+
+    if not transports:
+        return None
+    return _LifeSmartDiscoveryTransport(transports)
 
 
 def _send_discovery_probes(

--- a/custom_components/lifesmart/manifest.json
+++ b/custom_components/lifesmart/manifest.json
@@ -6,7 +6,8 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "infrared"
+    "infrared",
+    "network"
   ],
   "documentation": "https://github.com/iKaew/hass-lifesmart-addon",
   "integration_type": "hub",

--- a/tests/test_lifesmart_discovery_security.py
+++ b/tests/test_lifesmart_discovery_security.py
@@ -68,12 +68,19 @@ def test_discovery_socket_binds_specific_interface(monkeypatch):
             assert isinstance(factory(), local_module._LifeSmartDiscoveryProtocol)
             return transport, Mock()
 
-    monkeypatch.setattr(local_module.socket, "socket", FakeSocket)
-    monkeypatch.setattr(local_module.asyncio, "get_running_loop", lambda: FakeLoop())
+    async def scenario():
+        # Patch socket creation only after asyncio.run() has created its own
+        # event-loop self-pipe; patching socket.socket before that would replace
+        # asyncio's internal sockets with FakeSocket too.
+        monkeypatch.setattr(local_module.socket, "socket", FakeSocket)
+        monkeypatch.setattr(
+            local_module.asyncio, "get_running_loop", lambda: FakeLoop()
+        )
+        return await local_module._async_open_discovery_socket(
+            "192.168.1.10", 60021, {}
+        )
 
-    result = asyncio.run(
-        local_module._async_open_discovery_socket("192.168.1.10", 60021, {})
-    )
+    result = asyncio.run(scenario())
 
     assert result is transport
     assert sockets[0].bound == ("192.168.1.10", 60021)

--- a/tests/test_lifesmart_discovery_security.py
+++ b/tests/test_lifesmart_discovery_security.py
@@ -1,0 +1,112 @@
+"""Security-focused tests for LifeSmart local discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from ipaddress import IPv4Address, IPv6Address
+from unittest.mock import AsyncMock, Mock
+
+import custom_components.lifesmart.lifesmart_client_local as local_module
+
+
+def test_discovery_source_ips_use_enabled_home_assistant_ipv4(monkeypatch):
+    hass = object()
+    monkeypatch.setattr(local_module, "async_get_hass_or_none", lambda: hass)
+    get_source_ips = AsyncMock(
+        return_value=[
+            IPv4Address("192.168.1.10"),
+            IPv6Address("fe80::1"),
+            IPv4Address("192.168.1.10"),
+            IPv4Address("10.0.0.5"),
+            IPv4Address("0.0.0.0"),
+        ]
+    )
+    monkeypatch.setattr(
+        local_module.network, "async_get_enabled_source_ips", get_source_ips
+    )
+
+    source_ips = asyncio.run(local_module._async_get_discovery_source_ips())
+
+    assert source_ips == ["192.168.1.10", "10.0.0.5"]
+    get_source_ips.assert_awaited_once_with(hass)
+
+
+def test_discovery_source_ips_do_not_fall_back_to_wildcard(monkeypatch):
+    monkeypatch.setattr(local_module, "async_get_hass_or_none", lambda: None)
+
+    assert asyncio.run(local_module._async_get_discovery_source_ips()) == []
+
+
+def test_discovery_socket_binds_specific_interface(monkeypatch):
+    sockets = []
+
+    class FakeSocket:
+        def __init__(self, *args):
+            self.options = []
+            self.bound = None
+            self.closed = False
+            sockets.append(self)
+
+        def setblocking(self, value):
+            assert value is False
+
+        def setsockopt(self, level, option, value):
+            self.options.append((level, option, value))
+
+        def bind(self, address):
+            self.bound = address
+
+        def close(self):
+            self.closed = True
+
+    transport = Mock()
+
+    class FakeLoop:
+        async def create_datagram_endpoint(self, factory, *, sock):
+            assert sock is sockets[-1]
+            assert isinstance(factory(), local_module._LifeSmartDiscoveryProtocol)
+            return transport, Mock()
+
+    monkeypatch.setattr(local_module.socket, "socket", FakeSocket)
+    monkeypatch.setattr(local_module.asyncio, "get_running_loop", lambda: FakeLoop())
+
+    result = asyncio.run(
+        local_module._async_open_discovery_socket("192.168.1.10", 60021, {})
+    )
+
+    assert result is transport
+    assert sockets[0].bound == ("192.168.1.10", 60021)
+    assert sockets[0].bound[0] not in {"", "0.0.0.0"}
+    assert (
+        socket.IPPROTO_IP,
+        socket.IP_MULTICAST_IF,
+        socket.inet_aton("192.168.1.10"),
+    ) in sockets[0].options
+
+
+def test_discovery_transport_fans_out_to_all_enabled_interfaces(monkeypatch):
+    first = Mock()
+    second = Mock()
+    monkeypatch.setattr(
+        local_module,
+        "_async_get_discovery_source_ips",
+        AsyncMock(return_value=["192.168.1.10", "10.0.0.5"]),
+    )
+    open_socket = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(local_module, "_async_open_discovery_socket", open_socket)
+
+    transport = asyncio.run(local_module._async_open_discovery_transport(60021, {}))
+    destination = (
+        local_module.DISCOVERY_BROADCAST_HOST,
+        local_module.DISCOVERY_BROADCAST_PORT,
+    )
+    transport.sendto(local_module.DISCOVERY_SEARCH, destination)
+    transport.close()
+
+    assert open_socket.await_args_list[0].args[:2] == ("192.168.1.10", 60021)
+    assert open_socket.await_args_list[1].args[:2] == ("10.0.0.5", 60021)
+    first.sendto.assert_called_once_with(local_module.DISCOVERY_SEARCH, destination)
+    second.sendto.assert_called_once_with(local_module.DISCOVERY_SEARCH, destination)
+    first.close.assert_called_once()
+    second.close.assert_called_once()


### PR DESCRIPTION
## Summary

- replace wildcard UDP discovery binding with one socket per enabled Home Assistant IPv4 address
- set `IP_MULTICAST_IF` to the same concrete source address used by each socket
- avoid falling back to `0.0.0.0`; automatic discovery returns no results when Home Assistant has no enabled IPv4 source addresses
- declare the Home Assistant `network` integration as a dependency
- add security-focused tests for interface filtering, concrete binding, and multi-interface fan-out

This is intended to address CodeQL alert #4 (`bind-socket-all-network-interfaces`) without hard-coding interface names or breaking multihomed Home Assistant installations.