### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/iKaew/hass-lifesmart-addon/security/code-scanning/3](https://github.com/iKaew/hass-lifesmart-addon/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions immediately after the `on:` block (before `jobs:`) with at least `contents: read`, which is sufficient for checkout and typical test workflows. This preserves behavior while removing dependence on repo/org defaults. No imports, methods, or extra definitions are needed—just YAML key addition in `.github/workflows/tests.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
