### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hass.yml
+++ b/.github/workflows/hass.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   validate-hassfest:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/iKaew/hass-lifesmart-addon/security/code-scanning/2](https://github.com/iKaew/hass-lifesmart-addon/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped minimally. The best fix here is to set workflow-level permissions to `contents: read`, which applies to all jobs unless overridden and documents intended access clearly.

### What to change
- **File:** `.github/workflows/hass.yml`
- **Region:** After trigger definitions (`on:` block) and before `jobs:`
- **Change:** Insert:
  ```yml
  permissions:
    contents: read
  ```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
