### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,5 +1,8 @@
 name: Validate for HACS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/iKaew/hass-lifesmart-addon/security/code-scanning/1](https://github.com/iKaew/hass-lifesmart-addon/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix here: add workflow-level permissions just below `name` (or below `on`) so it applies to all jobs unless overridden. For this workflow, `contents: read` is the minimal and sufficient permission for checkout/validation.

File to change: `.github/workflows/hacs.yaml`  
Change region: top-level keys before `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
